### PR TITLE
feat: further optimizations & fix removing ids from zones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "rsbuf"
-version = "225.1.6"
+version = "225.1.7"
 dependencies = [
  "criterion",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "rsbuf"
-version = "225.1.5"
+version = "225.1.6"
 dependencies = [
  "criterion",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +609,7 @@ version = "225.1.5"
 dependencies = [
  "criterion",
  "getrandom",
+ "nohash-hasher",
  "num-bigint",
  "num-traits",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ pem = "3.0.4"
 num-traits = "0.2.19"
 once_cell = "1.20.2"
 getrandom = { version = "0.2.15", features = ["js"] }
+nohash-hasher = "0.2.0"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsbuf"
-version = "225.1.6"
+version = "225.1.7"
 edition = "2021"
 authors = ["2004Scape"]
 description = "A RuneScape update info computer."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsbuf"
-version = "225.1.5"
+version = "225.1.6"
 edition = "2021"
 authors = ["2004Scape"]
 description = "A RuneScape update info computer."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2004scape/rsbuf",
-  "version": "225.1.6",
+  "version": "225.1.7",
   "description": "A RuneScape update info computer",
   "main": "dist/rsbuf.js",
   "types": "dist/rsbuf.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2004scape/rsbuf",
-  "version": "225.1.5",
+  "version": "225.1.6",
   "description": "A RuneScape update info computer",
   "main": "dist/rsbuf.js",
   "types": "dist/rsbuf.d.ts",

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,9 +1,9 @@
-use std::collections::{HashMap, HashSet};
-use std::hash::{Hash, Hasher};
 use crate::coord::CoordGrid;
-use crate::player::Player;
 use crate::grid::ZoneMap;
 use crate::npc::Npc;
+use crate::player::Player;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 
 #[derive(Clone)]
 pub struct IdBitSet {
@@ -128,7 +128,7 @@ impl BuildArea {
     }
 
     #[inline]
-    pub fn rebuild_players(&mut self, players: &[Option<Player>], grid: &HashMap<u32, HashSet<i32>>, pid: i32, x: u16, y: u8, z: u16) {
+    pub fn rebuild_players(&mut self, players: &[Option<Player>], grid: &HashMap<u32, Vec<i32>>, pid: i32, x: u16, y: u8, z: u16) {
         // optimization to avoid sending 3 bits * observed players when everything has to be removed anyways
         self.players.clear();
         self.last_resize = 0;
@@ -149,7 +149,7 @@ impl BuildArea {
     }
 
     #[inline]
-    pub fn has_appearance(&self, pid: i32, tick: u32) -> bool {
+    pub const fn has_appearance(&self, pid: i32, tick: u32) -> bool {
         return unsafe { *self.appearances.as_ptr().add(pid as usize) == tick }
     }
 
@@ -162,7 +162,7 @@ impl BuildArea {
     pub fn get_nearby_players(
         &self,
         players: &[Option<Player>],
-        grid: &HashMap<u32, HashSet<i32>>,
+        grid: &HashMap<u32, Vec<i32>>,
         map: &mut ZoneMap,
         pid: i32,
         x: u16,
@@ -217,7 +217,7 @@ impl BuildArea {
     pub fn get_nearby_players_nearest(
         &self,
         players: &[Option<Player>],
-        grid: &HashMap<u32, HashSet<i32>>,
+        grid: &HashMap<u32, Vec<i32>>,
         pid: i32,
         x: u16,
         y: u8,
@@ -239,7 +239,7 @@ impl BuildArea {
                 return nearby;
             }
             if (min < dx && dx <= max) && (min < dz && dz <= max) {
-                if let Some(set) = grid.get(&CoordGrid::from(((x as i32) + dx) as u16, y, ((z as i32) + dz) as u16).coord) {
+                if let Some(set) = grid.get(&CoordGrid::from(((x as i32) + dx) as u16, y, ((z as i32) + dz) as u16).packed) {
                     nearby.extend(
                         set
                             .iter()

--- a/src/build.rs
+++ b/src/build.rs
@@ -50,8 +50,8 @@ impl IdBitSet {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const i32 {
-        return self.ids.as_ptr();
+    pub fn iter(&self) -> Vec<i32> {
+        return self.ids.iter().cloned().collect();
     }
 
     #[inline]

--- a/src/build.rs
+++ b/src/build.rs
@@ -3,7 +3,6 @@ use crate::grid::ZoneMap;
 use crate::npc::Npc;
 use crate::player::Player;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 
 #[derive(Clone)]
 pub struct IdBitSet {
@@ -325,15 +324,5 @@ impl BuildArea {
             return !(self.npcs.contains(npc) || !CoordGrid::within_distance_sw(&other.coord, &CoordGrid::from(x, y, z), BuildArea::PREFERRED_VIEW_DISTANCE) || other.nid == -1 || other.coord.y() != y || !other.active);
         }
         return false;
-    }
-}
-
-impl Hash for BuildArea {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // self.players.hash(state);
-        // self.appearances.hash(state);
-        self.force_view_distance.hash(state);
-        self.view_distance.hash(state);
-        self.last_resize.hash(state);
     }
 }

--- a/src/coord.rs
+++ b/src/coord.rs
@@ -1,45 +1,50 @@
 #[derive(Clone)]
 pub struct CoordGrid {
-    pub coord: u32,
+    pub packed: u32,
 }
 
 impl CoordGrid {
     #[inline]
-    pub fn new(coord: u32) -> CoordGrid {
-        return CoordGrid { coord };
+    pub const fn new(coord: u32) -> CoordGrid {
+        return CoordGrid { packed: coord };
     }
 
     #[inline]
-    pub fn from(x: u16, y: u8, z: u16) -> CoordGrid {
+    pub const fn from(x: u16, y: u8, z: u16) -> CoordGrid {
         return CoordGrid {
-            coord: ((z & 0x3fff) as u32)
+            packed: ((z & 0x3fff) as u32)
                 | (((x & 0x3fff) as u32) << 14)
                 | (((y & 0x3) as u32) << 28),
         };
     }
 
     #[inline]
-    pub fn y(&self) -> u8 {
-        return ((self.coord >> 28) & 0x3) as u8;
+    pub const fn y(&self) -> u8 {
+        return ((self.packed >> 28) & 0x3) as u8;
     }
 
     #[inline]
-    pub fn x(&self) -> u16 {
-        return ((self.coord >> 14) & 0x3fff) as u16;
+    pub const fn x(&self) -> u16 {
+        return ((self.packed >> 14) & 0x3fff) as u16;
     }
 
     #[inline]
-    pub fn z(&self) -> u16 {
-        return (self.coord & 0x3fff) as u16;
+    pub const fn z(&self) -> u16 {
+        return (self.packed & 0x3fff) as u16;
     }
 
     #[inline]
-    pub fn within_distance_sw(&self, other: &CoordGrid, distance: u8) -> bool {
+    pub const fn within_distance_sw(&self, other: &CoordGrid, distance: u8) -> bool {
         return !((self.x() as i32 - other.x() as i32).abs() > distance as i32 || (self.z() as i32 - other.z() as i32).abs() > distance as i32)
     }
 
     #[inline]
-    pub fn fine(pos: u16, size: i32) -> i32 {
+    pub const fn fine(pos: u16, size: i32) -> i32 {
         return pos as i32 * 2 + size;
+    }
+
+    #[inline]
+    pub const fn zone(pos: u16) -> u16 {
+        return pos >> 3;
     }
 }

--- a/src/coord.rs
+++ b/src/coord.rs
@@ -5,8 +5,8 @@ pub struct CoordGrid {
 
 impl CoordGrid {
     #[inline]
-    pub const fn new(coord: u32) -> CoordGrid {
-        return CoordGrid { packed: coord };
+    pub const fn new(packed: u32) -> CoordGrid {
+        return CoordGrid { packed };
     }
 
     #[inline]

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,18 +1,18 @@
-use std::collections::{HashMap, HashSet};
 use crate::build::BuildArea;
 use crate::coord::CoordGrid;
+use crate::grid::ZoneMap;
 use crate::message::{NpcInfoFaceCoord, NpcInfoFaceEntity, PlayerInfoFaceCoord, PlayerInfoFaceEntity};
+use crate::npc::Npc;
 use crate::packet::Packet;
 use crate::player::Player;
 use crate::prot::{NpcInfoProt, PlayerInfoProt};
 use crate::renderer::{NpcRenderer, PlayerRenderer};
-use crate::grid::ZoneMap;
-use crate::npc::Npc;
 use crate::visibility::Visibility;
+use std::collections::HashMap;
 
 pub struct PlayerInfo {
-    pub buf: Packet,
-    pub updates: Packet,
+    buf: Packet,
+    updates: Packet,
 }
 
 impl PlayerInfo {
@@ -36,7 +36,7 @@ impl PlayerInfo {
         renderer: &mut PlayerRenderer,
         players: &[Option<Player>],
         map: &mut ZoneMap,
-        grid: &HashMap<u32, HashSet<i32>>,
+        grid: &HashMap<u32, Vec<i32>>,
         player: &mut Player,
         dx: i32,
         dz: i32,
@@ -116,26 +116,29 @@ impl PlayerInfo {
             }
             match unsafe { *player.build.players.as_ptr().add(index) } {
                 pid => {
-                    if let Some(other) = unsafe { &*players.as_ptr().add(pid as usize) } {
-                        if other.pid == -1 || other.tele || other.coord.y() != player.coord.y() || !CoordGrid::within_distance_sw(&player.coord, &other.coord, player.build.view_distance) || !other.active || other.visibility == Visibility::HARD {
+                    match unsafe { &*players.as_ptr().add(pid as usize) } {
+                        Some(other) => {
+                            if other.pid == -1 || other.tele || other.coord.y() != player.coord.y() || !CoordGrid::within_distance_sw(&player.coord, &other.coord, player.build.view_distance) || !other.active || other.visibility == Visibility::HARD {
+                                self.remove(player, pid);
+                                index -= 1;
+                            } else {
+                                let len: usize = renderer.highdefinitions(pid);
+                                if other.run_dir != -1 {
+                                    self.run(renderer, player, other, len > 0 && self.fits(bytes + 2, PlayerInfo::BITS_RUN, len));
+                                } else if other.walk_dir != -1 {
+                                    self.walk(renderer, player, other, len > 0 && self.fits(bytes + 2, PlayerInfo::BITS_WALK, len));
+                                } else if len > 0 && self.fits(bytes + 2, PlayerInfo::BITS_EXTEND, len) {
+                                    self.extend(renderer, player, other);
+                                } else {
+                                    self.idle();
+                                }
+                                bytes += len + 2;
+                            }
+                        }
+                        _ => {
                             self.remove(player, pid);
                             index -= 1;
-                        } else {
-                            let len: usize = renderer.highdefinitions(pid);
-                            if other.run_dir != -1 {
-                                self.run(renderer, player, other, len > 0 && self.fits(bytes + 2, PlayerInfo::BITS_RUN, len));
-                            } else if other.walk_dir != -1 {
-                                self.walk(renderer, player, other, len > 0 && self.fits(bytes + 2, PlayerInfo::BITS_WALK, len));
-                            } else if len > 0 && self.fits(bytes + 2, PlayerInfo::BITS_EXTEND, len) {
-                                self.extend(renderer, player, other);
-                            } else {
-                                self.idle();
-                            }
-                            bytes += len + 2;
                         }
-                    } else {
-                        self.remove(player, pid);
-                        index -= 1;
                     }
                 }
             }
@@ -150,7 +153,7 @@ impl PlayerInfo {
         map: &mut ZoneMap,
         players: &[Option<Player>],
         renderer: &mut PlayerRenderer,
-        grid: &HashMap<u32, HashSet<i32>>,
+        grid: &HashMap<u32, Vec<i32>>,
         player: &mut Player,
         mut bytes: usize
     ) {
@@ -296,12 +299,11 @@ impl PlayerInfo {
         player: &Player,
         other: &Player
     ) {
-        let myself: bool = player.pid == other.pid;
         let mut masks: u32 = other.masks;
-        if myself {
+        if player.pid == other.pid {
             masks &= !(PlayerInfoProt::CHAT as u32);
         }
-        self.write_blocks(renderer, player, other, other.pid, masks, myself);
+        self.write_blocks(renderer, player, other, masks);
     }
 
     #[inline]
@@ -354,7 +356,7 @@ impl PlayerInfo {
 
         masks |= PlayerInfoProt::FACE_COORD as u32;
 
-        self.write_blocks(renderer, player, other, pid, masks, false);
+        self.write_blocks(renderer, player, other, masks);
     }
 
     #[inline]
@@ -363,9 +365,7 @@ impl PlayerInfo {
         renderer: &mut PlayerRenderer,
         player: &Player,
         other: &Player,
-        pid: i32,
         mut masks: u32,
-        myself: bool
     ) {
         if masks > 0xff {
             masks |= PlayerInfoProt::BIG as u32;
@@ -376,35 +376,33 @@ impl PlayerInfo {
         }
         // ----
         if masks & PlayerInfoProt::APPEARANCE as u32 != 0 {
-            renderer.write(&mut self.updates, pid, PlayerInfoProt::APPEARANCE);
+            renderer.write(&mut self.updates, other.pid, PlayerInfoProt::APPEARANCE);
         }
         if masks & PlayerInfoProt::ANIM as u32 != 0 {
-            renderer.write(&mut self.updates, pid, PlayerInfoProt::ANIM);
+            renderer.write(&mut self.updates, other.pid, PlayerInfoProt::ANIM);
         }
         if masks & PlayerInfoProt::FACE_ENTITY as u32 != 0 {
-            renderer.write(&mut self.updates, pid, PlayerInfoProt::FACE_ENTITY);
+            renderer.write(&mut self.updates, other.pid, PlayerInfoProt::FACE_ENTITY);
         }
         if masks & PlayerInfoProt::SAY as u32 != 0 {
-            renderer.write(&mut self.updates, pid, PlayerInfoProt::SAY);
+            renderer.write(&mut self.updates, other.pid, PlayerInfoProt::SAY);
         }
         if masks & PlayerInfoProt::DAMAGE as u32 != 0 {
-            renderer.write(&mut self.updates, pid, PlayerInfoProt::DAMAGE);
+            renderer.write(&mut self.updates, other.pid, PlayerInfoProt::DAMAGE);
         }
         if masks & PlayerInfoProt::FACE_COORD as u32 != 0 {
-            renderer.write(&mut self.updates, pid, PlayerInfoProt::FACE_COORD);
+            renderer.write(&mut self.updates, other.pid, PlayerInfoProt::FACE_COORD);
         }
-        if !myself && masks & PlayerInfoProt::CHAT as u32 != 0 {
-            renderer.write(&mut self.updates, pid, PlayerInfoProt::CHAT);
+        if masks & PlayerInfoProt::CHAT as u32 != 0 {
+            renderer.write(&mut self.updates, other.pid, PlayerInfoProt::CHAT);
         }
         if masks & PlayerInfoProt::SPOT_ANIM as u32 != 0 {
-            renderer.write(&mut self.updates, pid, PlayerInfoProt::SPOT_ANIM);
+            renderer.write(&mut self.updates, other.pid, PlayerInfoProt::SPOT_ANIM);
         }
         if masks & PlayerInfoProt::EXACT_MOVE as u32 != 0 {
             if let Some(exactmove) = &other.exact_move {
-                let mut x = player.origin.x() as i32;
-                x = ((x >> 3) - 6) << 3;
-                let mut z = player.origin.z() as i32;
-                z = ((z >> 3) - 6) << 3;
+                let x: i32 = (((player.origin.x() as i32) >> 3) - 6) << 3;
+                let z: i32 = (((player.origin.z() as i32) >> 3) - 6) << 3;
                 renderer.writeExactmove(
                     &mut self.updates,
                     exactmove.start_x - x,
@@ -420,15 +418,15 @@ impl PlayerInfo {
     }
 
     #[inline]
-    fn fits(&self, bytes: usize, bits_to_add: usize, bytes_to_add: usize) -> bool {
+    const fn fits(&self, bytes: usize, bits_to_add: usize, bytes_to_add: usize) -> bool {
         // 7 aligns to the next byte
         return ((self.buf.bit_pos + bits_to_add + 7) >> 3) + bytes + bytes_to_add <= 4997;
     }
 }
 
 pub struct NpcInfo {
-    pub buf: Packet,
-    pub updates: Packet,
+    buf: Packet,
+    updates: Packet,
 }
 
 impl NpcInfo {
@@ -498,27 +496,30 @@ impl NpcInfo {
             }
             match unsafe { *player.build.npcs.as_ptr().add(index) } {
                 nid => {
-                    if let Some(other) = unsafe { &mut *npcs.as_mut_ptr().add(nid as usize) } {
-                        if other.nid == -1 || other.tele || other.coord.y() != player.coord.y() || !CoordGrid::within_distance_sw(&player.coord, &other.coord, BuildArea::PREFERRED_VIEW_DISTANCE) || !other.active {
-                            self.remove(player, nid);
-                            other.observers = (other.observers - 1).max(0);
-                            index -= 1;
-                        } else {
-                            let len: usize = renderer.highdefinitions(nid);
-                            if other.run_dir != -1 {
-                                self.run(renderer, other, len > 0 && self.fits(bytes + 1, NpcInfo::BITS_RUN, len));
-                            } else if other.walk_dir != -1 {
-                                self.walk(renderer, other, len > 0 && self.fits(bytes + 1, NpcInfo::BITS_WALK, len));
-                            } else if len > 0 && self.fits(bytes + 1, NpcInfo::BITS_EXTEND, len) {
-                                self.extend(renderer, other);
+                    match unsafe { &mut *npcs.as_mut_ptr().add(nid as usize) } {
+                        Some(other) => {
+                            if other.nid == -1 || other.tele || other.coord.y() != player.coord.y() || !CoordGrid::within_distance_sw(&player.coord, &other.coord, BuildArea::PREFERRED_VIEW_DISTANCE) || !other.active {
+                                self.remove(player, nid);
+                                other.observers = (other.observers - 1).max(0);
+                                index -= 1;
                             } else {
-                                self.idle();
+                                let len: usize = renderer.highdefinitions(nid);
+                                if other.run_dir != -1 {
+                                    self.run(renderer, other, len > 0 && self.fits(bytes + 1, NpcInfo::BITS_RUN, len));
+                                } else if other.walk_dir != -1 {
+                                    self.walk(renderer, other, len > 0 && self.fits(bytes + 1, NpcInfo::BITS_WALK, len));
+                                } else if len > 0 && self.fits(bytes + 1, NpcInfo::BITS_EXTEND, len) {
+                                    self.extend(renderer, other);
+                                } else {
+                                    self.idle();
+                                }
+                                bytes += len + 1;
                             }
-                            bytes += len + 1;
                         }
-                    } else {
-                        self.remove(player, nid);
-                        index -= 1;
+                        _ => {
+                            self.remove(player, nid);
+                            index -= 1;
+                        }
                     }
                 }
             }
@@ -704,6 +705,8 @@ impl NpcInfo {
     ) {
         self.updates.p1((masks & 0xff) as i32);
         // ----
+        // an optimization *could* be made where all of these are just 1 block of bytes...
+        // the same could NOT be done for players bcuz of how exact_move works...
         if masks & NpcInfoProt::ANIM as u32 != 0 {
             renderer.write(&mut self.updates, nid, NpcInfoProt::ANIM);
         }
@@ -728,7 +731,7 @@ impl NpcInfo {
     }
 
     #[inline]
-    fn fits(&self, bytes: usize, bits_to_add: usize, bytes_to_add: usize) -> bool {
+    const fn fits(&self, bytes: usize, bits_to_add: usize, bytes_to_add: usize) -> bool {
         // 7 aligns to the next byte
         return ((self.buf.bit_pos + bits_to_add + 7) >> 3) + bytes + bytes_to_add <= 4997;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,8 +188,10 @@ pub unsafe fn remove_player(pid: i32) {
     if pid == -1 {
         return;
     }
-    PLAYER_RENDERER.removePermanent(pid);
     if let Some(player) = &mut *PLAYERS.as_mut_ptr().add(pid as usize) {
+        // remove player from zone.
+        ZONE_MAP.zone(player.coord.x(), player.coord.y(), player.coord.z()).remove_player(pid);
+
         let len: usize = player.build.npcs.len();
         let mut index: usize = 0;
         while index < len {
@@ -207,6 +209,7 @@ pub unsafe fn remove_player(pid: i32) {
         }
         player.build.cleanup();
     }
+    PLAYER_RENDERER.removePermanent(pid);
     *PLAYERS.as_mut_ptr().add(pid as usize) = None;
 }
 
@@ -322,6 +325,10 @@ pub unsafe fn add_npc(nid: i32, ntype: i32) {
 pub unsafe fn remove_npc(nid: i32) {
     if nid == -1 {
         return;
+    }
+    if let Some(npc) = &*NPCS.as_ptr().add(nid as usize) {
+        // remove npc from zone.
+        ZONE_MAP.zone(npc.coord.x(), npc.coord.y(), npc.coord.z()).remove_npc(nid);
     }
     NPC_RENDERER.removePermanent(nid);
     *NPCS.as_mut_ptr().add(nid as usize) = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,21 +191,10 @@ pub unsafe fn remove_player(pid: i32) {
     if let Some(player) = &mut *PLAYERS.as_mut_ptr().add(pid as usize) {
         // remove player from zone.
         ZONE_MAP.zone(player.coord.x(), player.coord.y(), player.coord.z()).remove_player(pid);
-
-        let len: usize = player.build.npcs.len();
-        let mut index: usize = 0;
-        while index < len {
-            if index >= player.build.npcs.len() {
-                break;
+        for nid in player.build.npcs.iter() {
+            if let Some(npc) = unsafe { &mut *NPCS.as_mut_ptr().add(nid as usize) } {
+                npc.observers = (npc.observers - 1).max(0);
             }
-            match unsafe { *player.build.npcs.as_ptr().add(index) } {
-                nid => {
-                    if let Some(npc) = unsafe { &mut *NPCS.as_mut_ptr().add(nid as usize) } {
-                        npc.observers = (npc.observers - 1).max(0);
-                    }
-                }
-            }
-            index += 1;
         }
         player.build.cleanup();
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -9,12 +9,12 @@ pub trait InfoMessage {
 // ---- players
 
 pub struct PlayerInfoAppearance {
-    pub bytes: Vec<u8>,
+    bytes: Vec<u8>,
 }
 
 impl PlayerInfoAppearance {
     #[inline]
-    pub fn new(bytes: Vec<u8>) -> PlayerInfoAppearance {
+    pub const fn new(bytes: Vec<u8>) -> PlayerInfoAppearance {
         return PlayerInfoAppearance {
             bytes,
         };
@@ -42,12 +42,12 @@ impl InfoMessage for PlayerInfoAppearance {
 // ----
 
 pub struct PlayerInfoFaceEntity {
-    pub entity: i32,
+    entity: i32,
 }
 
 impl PlayerInfoFaceEntity {
     #[inline]
-    pub fn new(entity: i32) -> PlayerInfoFaceEntity {
+    pub const fn new(entity: i32) -> PlayerInfoFaceEntity {
         return PlayerInfoFaceEntity {
             entity,
         }
@@ -74,13 +74,13 @@ impl InfoMessage for PlayerInfoFaceEntity {
 // ----
 
 pub struct PlayerInfoFaceCoord {
-    pub x: i32,
-    pub z: i32,
+    x: i32,
+    z: i32,
 }
 
 impl PlayerInfoFaceCoord {
     #[inline]
-    pub fn new(
+    pub const fn new(
         x: i32,
         z: i32
     ) -> PlayerInfoFaceCoord {
@@ -112,13 +112,13 @@ impl InfoMessage for PlayerInfoFaceCoord {
 // ----
 
 pub struct PlayerInfoAnim {
-    pub anim: i32,
-    pub delay: i32,
+    anim: i32,
+    delay: i32,
 }
 
 impl PlayerInfoAnim {
     #[inline]
-    pub fn new(
+    pub const fn new(
         anim: i32,
         delay: i32
     ) -> PlayerInfoAnim {
@@ -150,12 +150,12 @@ impl InfoMessage for PlayerInfoAnim {
 // ----
 
 pub struct PlayerInfoSay {
-    pub say: String
+    say: String
 }
 
 impl PlayerInfoSay {
     #[inline]
-    pub fn new(say: String) -> PlayerInfoSay {
+    pub const fn new(say: String) -> PlayerInfoSay {
         return PlayerInfoSay {
             say,
         }
@@ -182,15 +182,15 @@ impl InfoMessage for PlayerInfoSay {
 // ----
 
 pub struct PlayerInfoDamage {
-    pub damage: i32,
-    pub damage_type: i32,
-    pub current_hitpoints: i32,
-    pub base_hitpoints: i32,
+    damage: i32,
+    damage_type: i32,
+    current_hitpoints: i32,
+    base_hitpoints: i32,
 }
 
 impl PlayerInfoDamage {
     #[inline]
-    pub fn new(
+    pub const fn new(
         damage: i32,
         damage_type: i32,
         current_hitpoints: i32,
@@ -236,7 +236,7 @@ pub struct PlayerInfoChat {
 
 impl PlayerInfoChat {
     #[inline]
-    pub fn new(
+    pub const fn new(
         bytes: Vec<u8>,
         color: i32,
         effect: i32,
@@ -275,14 +275,14 @@ impl InfoMessage for PlayerInfoChat {
 // ----
 
 pub struct PlayerInfoSpotanim {
-    pub graphic_id: i32,
-    pub graphic_height: i32,
-    pub graphic_delay: i32,
+    graphic_id: i32,
+    graphic_height: i32,
+    graphic_delay: i32,
 }
 
 impl PlayerInfoSpotanim {
     #[inline]
-    pub fn new(
+    pub const fn new(
         graphic_id: i32,
         graphic_height: i32,
         graphic_delay: i32
@@ -316,18 +316,18 @@ impl InfoMessage for PlayerInfoSpotanim {
 // ----
 
 pub struct PlayerInfoExactMove {
-    pub start_x: i32,
-    pub start_z: i32,
-    pub end_x: i32,
-    pub end_z: i32,
-    pub begin: i32,
-    pub finish: i32,
-    pub dir: i32
+    start_x: i32,
+    start_z: i32,
+    end_x: i32,
+    end_z: i32,
+    begin: i32,
+    finish: i32,
+    dir: i32
 }
 
 impl PlayerInfoExactMove {
     #[inline]
-    pub fn new(
+    pub const fn new(
         start_x: i32,
         start_z: i32,
         end_x: i32,
@@ -374,12 +374,12 @@ impl InfoMessage for PlayerInfoExactMove {
 // ---- npcs
 
 pub struct NpcInfoFaceEntity {
-    pub entity: i32,
+    entity: i32,
 }
 
 impl NpcInfoFaceEntity {
     #[inline]
-    pub fn new(entity: i32) -> NpcInfoFaceEntity {
+    pub const fn new(entity: i32) -> NpcInfoFaceEntity {
         return NpcInfoFaceEntity {
             entity,
         }
@@ -406,13 +406,13 @@ impl InfoMessage for NpcInfoFaceEntity {
 // ----
 
 pub struct NpcInfoFaceCoord {
-    pub x: i32,
-    pub z: i32,
+    x: i32,
+    z: i32,
 }
 
 impl NpcInfoFaceCoord {
     #[inline]
-    pub fn new(
+    pub const fn new(
         x: i32,
         z: i32
     ) -> NpcInfoFaceCoord {
@@ -444,13 +444,13 @@ impl InfoMessage for NpcInfoFaceCoord {
 // ----
 
 pub struct NpcInfoAnim {
-    pub anim: i32,
-    pub delay: i32,
+    anim: i32,
+    delay: i32,
 }
 
 impl NpcInfoAnim {
     #[inline]
-    pub fn new(
+    pub const fn new(
         anim: i32,
         delay: i32
     ) -> NpcInfoAnim {
@@ -482,12 +482,12 @@ impl InfoMessage for NpcInfoAnim {
 // ----
 
 pub struct NpcInfoSay {
-    pub say: String
+    say: String
 }
 
 impl NpcInfoSay {
     #[inline]
-    pub fn new(say: String) -> NpcInfoSay {
+    pub const fn new(say: String) -> NpcInfoSay {
         return NpcInfoSay {
             say,
         }
@@ -514,15 +514,15 @@ impl InfoMessage for NpcInfoSay {
 // ----
 
 pub struct NpcInfoDamage {
-    pub damage: i32,
-    pub damage_type: i32,
-    pub current_hitpoints: i32,
-    pub base_hitpoints: i32,
+    damage: i32,
+    damage_type: i32,
+    current_hitpoints: i32,
+    base_hitpoints: i32,
 }
 
 impl NpcInfoDamage {
     #[inline]
-    pub fn new(
+    pub const fn new(
         damage: i32,
         damage_type: i32,
         current_hitpoints: i32,
@@ -560,12 +560,12 @@ impl InfoMessage for NpcInfoDamage {
 // ----
 
 pub struct NpcInfoChangeType {
-    pub change_type: i32,
+    change_type: i32,
 }
 
 impl NpcInfoChangeType {
     #[inline]
-    pub fn new(change_type: i32) -> NpcInfoChangeType {
+    pub const fn new(change_type: i32) -> NpcInfoChangeType {
         return NpcInfoChangeType {
             change_type,
         }
@@ -589,14 +589,14 @@ impl InfoMessage for NpcInfoChangeType {
 // ----
 
 pub struct NpcInfoSpotanim {
-    pub graphic_id: i32,
-    pub graphic_height: i32,
-    pub graphic_delay: i32,
+    graphic_id: i32,
+    graphic_height: i32,
+    graphic_delay: i32,
 }
 
 impl NpcInfoSpotanim {
     #[inline]
-    pub fn new(
+    pub const fn new(
         graphic_id: i32,
         graphic_height: i32,
         graphic_delay: i32

--- a/src/npc.rs
+++ b/src/npc.rs
@@ -30,7 +30,7 @@ pub struct Npc {
 
 impl Npc {
     #[inline]
-    pub fn new(nid: i32, ntype: i32) -> Npc {
+    pub const fn new(nid: i32, ntype: i32) -> Npc {
         return Npc {
             coord: CoordGrid::from(0, 0, 0),
             nid,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -982,10 +982,10 @@ impl Packet {
         let mut byte_pos: usize = pos >> 3;
         let mut remaining: usize = 8 - (pos & 7);
 
-        let mut result: u8 = 0;
+        let mut result: i32 = 0;
 
         while n > remaining {
-            result |= (unsafe { *self.data.as_ptr().add(byte_pos) } & (1 << remaining) - 1)
+            result |= (unsafe { *self.data.as_ptr().add(byte_pos) as i32 } & (1 << remaining) - 1)
                 << (n - remaining);
             byte_pos += 1;
             n -= remaining;
@@ -993,12 +993,12 @@ impl Packet {
         }
 
         if n == remaining {
-            result |= unsafe { *self.data.as_ptr().add(byte_pos) } & (1 << remaining) - 1;
+            result |= unsafe { *self.data.as_ptr().add(byte_pos) as i32 } & (1 << remaining) - 1;
         } else {
             result |=
-                (unsafe { *self.data.as_ptr().add(byte_pos) } >> (remaining - n)) & (1 << n) - 1;
+                (unsafe { *self.data.as_ptr().add(byte_pos) as i32 } >> (remaining - n)) & (1 << n) - 1;
         }
-        return result as i32;
+        return result;
     }
 
     /// Writes a specified number of bits to the internal buffer, starting from the current bit position (`self.bit_pos`).

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,10 +1,10 @@
-use std::io::Error;
 use num_bigint::BigInt;
 use num_traits::identities::One;
 use pem::{parse, Pem};
 use rsa::pkcs8::DecodePrivateKey;
-use rsa::RsaPrivateKey;
 use rsa::traits::{PrivateKeyParts, PublicKeyParts};
+use rsa::RsaPrivateKey;
+use std::io::Error;
 
 #[derive(Clone)]
 pub struct Packet {
@@ -44,7 +44,7 @@ impl Packet {
     ///
     /// let packet: Packet = Packet::from(vec![0; 128]);
     /// ```
-    pub fn from(data: Vec<u8>) -> Packet {
+    pub const fn from(data: Vec<u8>) -> Packet {
         return Packet {
             data,
             pos: 0,
@@ -120,7 +120,7 @@ impl Packet {
     /// contract.
     #[inline]
     pub fn p1(&mut self, value: i32) {
-        unsafe { *self.data.get_unchecked_mut(self.pos) = value as u8 }
+        unsafe { *self.data.as_mut_ptr().add(self.pos) = value as u8 }
         self.pos += 1;
     }
 
@@ -474,7 +474,7 @@ impl Packet {
     #[inline]
     pub fn g1(&mut self) -> u8 {
         self.pos += 1;
-        return unsafe { *self.data.get_unchecked(self.pos - 1) };
+        return unsafe { *self.data.as_ptr().add(self.pos - 1) };
     }
 
     /// Reads one byte from the internal buffer, interprets them as a signed 8-bit integer (`i8`),
@@ -1044,7 +1044,7 @@ impl Packet {
         let mut remaining: usize = 8 - (pos & 7);
 
         while n > remaining {
-            let shift: i32 = ((1 << remaining) - 1) as i32;
+            let shift: i32 = (1 << remaining) - 1;
             let byte: i32 = unsafe { *self.data.as_ptr().add(byte_pos) } as i32;
             unsafe {
                 *self.data.as_mut_ptr().add(byte_pos) =

--- a/src/player.rs
+++ b/src/player.rs
@@ -123,7 +123,7 @@ impl Player {
 
 impl ExactMove {
     #[inline]
-    pub fn new(
+    pub const fn new(
         start_x: i32,
         start_z: i32,
         end_x: i32,
@@ -146,7 +146,7 @@ impl ExactMove {
 
 impl Chat {
     #[inline]
-    pub fn new(
+    pub const fn new(
         bytes: Vec<u8>,
         color: u8,
         effect: u8,

--- a/src/prot.rs
+++ b/src/prot.rs
@@ -18,6 +18,25 @@ pub enum PlayerInfoProt {
     EXACT_MOVE = 0x200,
 }
 
+impl PlayerInfoProt {
+    #[inline]
+    pub const fn to_index(self) -> usize {
+        // the ordering here does not matter.
+        return match self {
+            PlayerInfoProt::APPEARANCE => 0,
+            PlayerInfoProt::ANIM => 1,
+            PlayerInfoProt::FACE_ENTITY => 2,
+            PlayerInfoProt::SAY => 3,
+            PlayerInfoProt::DAMAGE => 4,
+            PlayerInfoProt::FACE_COORD => 5,
+            PlayerInfoProt::CHAT => 6,
+            PlayerInfoProt::SPOT_ANIM => 7,
+            PlayerInfoProt::BIG => 255, // unused
+            PlayerInfoProt::EXACT_MOVE => 255, // unused
+        }
+    }
+}
+
 #[repr(u16)]
 #[derive(Eq, Hash, PartialEq)]
 #[wasm_bindgen]
@@ -29,4 +48,20 @@ pub enum NpcInfoProt {
     CHANGE_TYPE = 0x20,
     SPOT_ANIM = 0x40,
     FACE_COORD = 0x80,
+}
+
+impl NpcInfoProt {
+    #[inline]
+    pub const fn to_index(self) -> usize {
+        // the ordering here does not matter.
+        return match self {
+            NpcInfoProt::ANIM => 0,
+            NpcInfoProt::FACE_ENTITY => 1,
+            NpcInfoProt::SAY => 2,
+            NpcInfoProt::DAMAGE => 3,
+            NpcInfoProt::CHANGE_TYPE => 4,
+            NpcInfoProt::SPOT_ANIM => 5,
+            NpcInfoProt::FACE_COORD => 6,
+        }
+    }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -13,19 +13,9 @@ pub struct PlayerRenderer {
 impl PlayerRenderer {
     #[inline]
     pub fn new() -> PlayerRenderer {
-        let mut caches: Vec<Vec<Option<Vec<u8>>>> = vec![vec![None; 2048]; 8];
-        // the ordering here does not matter.
-        caches[PlayerInfoProt::APPEARANCE.to_index()] = vec![None; 2048];
-        caches[PlayerInfoProt::ANIM.to_index()] = vec![None; 2048];
-        caches[PlayerInfoProt::FACE_ENTITY.to_index()] = vec![None; 2048];
-        caches[PlayerInfoProt::SAY.to_index()] = vec![None; 2048];
-        caches[PlayerInfoProt::DAMAGE.to_index()] = vec![None; 2048];
-        caches[PlayerInfoProt::FACE_COORD.to_index()] = vec![None; 2048];
-        caches[PlayerInfoProt::CHAT.to_index()] = vec![None; 2048];
-        caches[PlayerInfoProt::SPOT_ANIM.to_index()] = vec![None; 2048];
         // exact move does not get cached, that is built on demand.
         return PlayerRenderer {
-            caches,
+            caches: vec![vec![None; 2048]; 8],
             highs: [0; 2048],
             lows: [0; 2048],
         }
@@ -174,11 +164,9 @@ impl PlayerRenderer {
     #[inline]
     pub fn write(&self, buf: &mut Packet, id: i32, prot: PlayerInfoProt) {
         unsafe {
-            let cache: &Vec<Option<Vec<u8>>> = &*self.caches.as_ptr().add(prot.to_index());
-            if let Some(bytes) = &*cache.as_ptr().add(id as usize) {
-                buf.pdata(bytes, 0, bytes.len());
-            } else {
-                panic!("[PlayerRenderer] Tried to write a buf not cached!");
+            match &*(&*self.caches.as_ptr().add(prot.to_index())).as_ptr().add(id as usize) {
+                Some(bytes) => buf.pdata(bytes, 0, bytes.len()),
+                _ => panic!("[PlayerRenderer] Tried to write a buf not cached!"),
             }
         }
     }
@@ -186,10 +174,7 @@ impl PlayerRenderer {
 
     #[inline]
     pub fn has(&self, id: i32, prot: PlayerInfoProt) -> bool {
-        unsafe {
-            let cache: &Vec<Option<Vec<u8>>> = &*self.caches.as_ptr().add(prot.to_index());
-            return (*cache.as_ptr().add(id as usize)).is_some();
-        }
+        return unsafe { (*(&*self.caches.as_ptr().add(prot.to_index())).as_ptr().add(id as usize)).is_some() };
     }
 
 
@@ -258,17 +243,8 @@ pub struct NpcRenderer {
 impl NpcRenderer {
     #[inline]
     pub fn new() -> NpcRenderer {
-        let mut caches: Vec<Vec<Option<Vec<u8>>>> = vec![vec![None; 8192]; 7];
-        // the ordering here does not matter.
-        caches[NpcInfoProt::ANIM.to_index()] = vec![None; 8192];
-        caches[NpcInfoProt::FACE_ENTITY.to_index()] = vec![None; 8192];
-        caches[NpcInfoProt::SAY.to_index()] = vec![None; 8192];
-        caches[NpcInfoProt::DAMAGE.to_index()] = vec![None; 8192];
-        caches[NpcInfoProt::CHANGE_TYPE.to_index()] = vec![None; 8192];
-        caches[NpcInfoProt::SPOT_ANIM.to_index()] = vec![None; 8192];
-        caches[NpcInfoProt::FACE_COORD.to_index()] = vec![None; 8192];
         return NpcRenderer {
-            caches,
+            caches: vec![vec![None; 8192]; 7],
             highs: [0; 8192],
             lows: [0; 8192],
         }
@@ -377,11 +353,9 @@ impl NpcRenderer {
     #[inline]
     pub fn write(&self, buf: &mut Packet, id: i32, prot: NpcInfoProt) {
         unsafe {
-            let cache: &Vec<Option<Vec<u8>>> = &*self.caches.as_ptr().add(prot.to_index());
-            if let Some(bytes) = &*cache.as_ptr().add(id as usize) {
-                buf.pdata(bytes, 0, bytes.len());
-            } else {
-                panic!("[NpcRenderer] Tried to write a buf not cached!");
+            match &*(&*self.caches.as_ptr().add(prot.to_index())).as_ptr().add(id as usize) {
+                Some(bytes) => buf.pdata(bytes, 0, bytes.len()),
+                _ => panic!("[NpcRenderer] Tried to write a buf not cached!"),
             }
         }
     }
@@ -389,10 +363,7 @@ impl NpcRenderer {
 
     #[inline]
     pub fn has(&self, id: i32, prot: NpcInfoProt) -> bool {
-        unsafe {
-            let cache: &Vec<Option<Vec<u8>>> = &*self.caches.as_ptr().add(prot.to_index());
-            return (*cache.as_ptr().add(id as usize)).is_some();
-        }
+        return unsafe { (*(&*self.caches.as_ptr().add(prot.to_index())).as_ptr().add(id as usize)).is_some() };
     }
 
 


### PR DESCRIPTION
### Optimizations
- Replace `HashMap` with `IntMap` from https://github.com/paritytech/nohash-hasher. Hashing is very slow in wasm, and this basically uses the keys of the map has the "hash". Also did the same with `IntSet` where possible. `Vec` `retain` is On.
- Marked constant functions that can try to be evaluated at compile time.
- Removed `myself: bool` from `write_blocks` to simplify that branch.
- Changed render caches from a `HashMap` to a `Vec` and utilize pointers.
- Made a bunch of public things not public.
- Remove and add players & npcs in zones when actually necessary. This is doing extra work for no reason.

### Fixes
- Pids and nids are now properly removed from zones. This was causing Npcs to become invisible.