### PR TITLE
feat: add support for damage2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2004scape/rsbuf",
-  "version": "225.1.7",
+  "version": "244.1.0",
   "description": "A RuneScape update info computer",
   "main": "dist/rsbuf.js",
   "types": "dist/rsbuf.d.ts",

--- a/src/info.rs
+++ b/src/info.rs
@@ -399,6 +399,9 @@ impl PlayerInfo {
                 )
             }
         }
+        if masks & PlayerInfoProt::DAMAGE2 as u32 != 0 {
+            renderer.write(&mut self.updates, other.pid, PlayerInfoProt::DAMAGE2);
+        }
     }
 
     #[inline]
@@ -677,6 +680,9 @@ impl NpcInfo {
         // ----
         // an optimization *could* be made where all of these are just 1 block of bytes...
         // the same could NOT be done for players bcuz of how exact_move works...
+        if masks & NpcInfoProt::DAMAGE2 as u32 != 0 {
+            renderer.write(&mut self.updates, nid, NpcInfoProt::DAMAGE2);
+        }
         if masks & NpcInfoProt::ANIM as u32 != 0 {
             renderer.write(&mut self.updates, nid, NpcInfoProt::ANIM);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub unsafe fn compute_player(
     orientationZ: i32,
     damageTaken: i32,
     damageType: i32,
+    damageTaken2: i32,
+    damageType2: i32,
     currentHitpoints: i32,
     baseHitpoints: i32,
     animId: i32,
@@ -136,6 +138,8 @@ pub unsafe fn compute_player(
         player.orientation_z = orientationZ;
         player.damage_taken = damageTaken;
         player.damage_type = damageType;
+        player.damage_taken2 = damageTaken2;
+        player.damage_type2 = damageType2;
         player.current_hitpoints = currentHitpoints;
         player.base_hitpoints = baseHitpoints;
         player.anim_id = animId;
@@ -232,6 +236,8 @@ pub unsafe fn compute_npc(
     orientationZ: i32,
     damageTaken: i32,
     damageType: i32,
+    damageTaken2: i32,
+    damageType2: i32,
     currentHitpoints: i32,
     baseHitpoints: i32,
     animId: i32,
@@ -267,6 +273,8 @@ pub unsafe fn compute_npc(
         npc.orientation_z = orientationZ;
         npc.damage_taken = damageTaken;
         npc.damage_type = damageType;
+        npc.damage_taken2 = damageTaken2;
+        npc.damage_type2 = damageType2;
         npc.current_hitpoints = currentHitpoints;
         npc.base_hitpoints = baseHitpoints;
         npc.anim_id = animId;

--- a/src/npc.rs
+++ b/src/npc.rs
@@ -17,6 +17,8 @@ pub struct Npc {
     pub orientation_z: i32,
     pub damage_taken: i32,
     pub damage_type: i32,
+    pub damage_taken2: i32,
+    pub damage_type2: i32,
     pub current_hitpoints: i32,
     pub base_hitpoints: i32,
     pub anim_id: i32,
@@ -47,6 +49,8 @@ impl Npc {
             orientation_z: -1,
             damage_taken: -1,
             damage_type: -1,
+            damage_taken2: -1,
+            damage_type2: -1,
             current_hitpoints: -1,
             base_hitpoints: -1,
             anim_id: -1,
@@ -72,6 +76,8 @@ impl Npc {
         // self.orientation_z = -1;
         self.damage_taken = -1;
         self.damage_type = -1;
+        self.damage_taken2 = -1;
+        self.damage_type2 = -1;
         self.current_hitpoints = -1;
         self.base_hitpoints = -1;
         self.anim_id = -1;

--- a/src/player.rs
+++ b/src/player.rs
@@ -24,6 +24,8 @@ pub struct Player {
     pub orientation_z: i32,
     pub damage_taken: i32,
     pub damage_type: i32,
+    pub damage_taken2: i32,
+    pub damage_type2: i32,
     pub current_hitpoints: i32,
     pub base_hitpoints: i32,
     pub anim_id: i32,
@@ -79,6 +81,8 @@ impl Player {
             orientation_z: -1,
             damage_taken: -1,
             damage_type: -1,
+            damage_taken2: -1,
+            damage_type2: -1,
             current_hitpoints: -1,
             base_hitpoints: -1,
             anim_id: -1,
@@ -108,6 +112,8 @@ impl Player {
         // self.orientation_z = -1;
         self.damage_taken = -1;
         self.damage_type = -1;
+        self.damage_taken2 = -1;
+        self.damage_type2 = -1;
         self.current_hitpoints = -1;
         self.base_hitpoints = -1;
         self.anim_id = -1;

--- a/src/prot.rs
+++ b/src/prot.rs
@@ -16,6 +16,7 @@ pub enum PlayerInfoProt {
     BIG = 0x80,
     SPOT_ANIM = 0x100,
     EXACT_MOVE = 0x200,
+    DAMAGE2 = 0x400,
 }
 
 impl PlayerInfoProt {
@@ -28,9 +29,10 @@ impl PlayerInfoProt {
             PlayerInfoProt::FACE_ENTITY => 2,
             PlayerInfoProt::SAY => 3,
             PlayerInfoProt::DAMAGE => 4,
-            PlayerInfoProt::FACE_COORD => 5,
-            PlayerInfoProt::CHAT => 6,
-            PlayerInfoProt::SPOT_ANIM => 7,
+            PlayerInfoProt::DAMAGE2 => 5,
+            PlayerInfoProt::FACE_COORD => 6,
+            PlayerInfoProt::CHAT => 7,
+            PlayerInfoProt::SPOT_ANIM => 8,
             PlayerInfoProt::BIG => 255, // unused
             PlayerInfoProt::EXACT_MOVE => 255, // unused
         }
@@ -41,6 +43,7 @@ impl PlayerInfoProt {
 #[derive(Eq, Hash, PartialEq)]
 #[wasm_bindgen]
 pub enum NpcInfoProt {
+    DAMAGE2 = 0x1,
     ANIM = 0x2,
     FACE_ENTITY = 0x4,
     SAY = 0x8,
@@ -59,9 +62,10 @@ impl NpcInfoProt {
             NpcInfoProt::FACE_ENTITY => 1,
             NpcInfoProt::SAY => 2,
             NpcInfoProt::DAMAGE => 3,
-            NpcInfoProt::CHANGE_TYPE => 4,
-            NpcInfoProt::SPOT_ANIM => 5,
-            NpcInfoProt::FACE_COORD => 6,
+            NpcInfoProt::DAMAGE2 => 4,
+            NpcInfoProt::CHANGE_TYPE => 5,
+            NpcInfoProt::SPOT_ANIM => 6,
+            NpcInfoProt::FACE_COORD => 7,
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -81,6 +81,18 @@ impl PlayerRenderer {
                 PlayerInfoProt::DAMAGE,
             );
         }
+        if masks & PlayerInfoProt::DAMAGE2 as u32 != 0 {
+            highs += self.cache(
+                pid,
+                &PlayerInfoDamage::new(
+                    player.damage_taken2,
+                    player.damage_type2,
+                    player.current_hitpoints,
+                    player.base_hitpoints,
+                ),
+                PlayerInfoProt::DAMAGE2,
+            );
+        }
         if masks & PlayerInfoProt::FACE_COORD as u32 != 0 {
             let len: usize = self.cache(
                 pid,
@@ -196,6 +208,7 @@ impl PlayerRenderer {
             PlayerInfoProt::FACE_ENTITY.to_index(),
             PlayerInfoProt::SAY.to_index(),
             PlayerInfoProt::DAMAGE.to_index(),
+            PlayerInfoProt::DAMAGE2.to_index(),
             PlayerInfoProt::FACE_COORD.to_index(),
             PlayerInfoProt::CHAT.to_index(),
             PlayerInfoProt::SPOT_ANIM.to_index(),
@@ -301,6 +314,18 @@ impl NpcRenderer {
                 NpcInfoProt::DAMAGE,
             );
         }
+        if masks & NpcInfoProt::DAMAGE2 as u32 != 0 {
+            highs += self.cache(
+                nid,
+                &NpcInfoDamage::new(
+                    npc.damage_taken2,
+                    npc.damage_type2,
+                    npc.current_hitpoints,
+                    npc.base_hitpoints,
+                ),
+                NpcInfoProt::DAMAGE2,
+            );
+        }
         if masks & NpcInfoProt::CHANGE_TYPE as u32 != 0 {
             highs += self.cache(
                 nid,
@@ -385,6 +410,7 @@ impl NpcRenderer {
             NpcInfoProt::FACE_ENTITY.to_index(),
             NpcInfoProt::SAY.to_index(),
             NpcInfoProt::DAMAGE.to_index(),
+            NpcInfoProt::DAMAGE2.to_index(),
             NpcInfoProt::CHANGE_TYPE.to_index(),
             NpcInfoProt::SPOT_ANIM.to_index(),
             NpcInfoProt::FACE_COORD.to_index(),

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -15,7 +15,7 @@ impl PlayerRenderer {
     pub fn new() -> PlayerRenderer {
         // exact move does not get cached, that is built on demand.
         return PlayerRenderer {
-            caches: vec![vec![None; 2048]; 8],
+            caches: vec![vec![None; 2048]; 9],
             highs: [0; 2048],
             lows: [0; 2048],
         }
@@ -257,7 +257,7 @@ impl NpcRenderer {
     #[inline]
     pub fn new() -> NpcRenderer {
         return NpcRenderer {
-            caches: vec![vec![None; 8192]; 7],
+            caches: vec![vec![None; 8192]; 8],
             highs: [0; 8192],
             lows: [0; 8192],
         }


### PR DESCRIPTION
Adds support for `damage2` update flag present in the future 244 revision. A few notes:

* Haven't tested this as I'm not sure how, suggestions are welcome.
* This should probably target a 244 branch and not 225.
* This should increase the cargo & npm package version.